### PR TITLE
Fix assigning Flowing Water (regression from 6b00a3430d080ecf0b47ed0e13b...

### DIFF
--- a/worldloader.cpp
+++ b/worldloader.cpp
@@ -1032,7 +1032,7 @@ static inline void assignBlock(const uint8_t &block, uint8_t* &targetBlock, int 
 {
 	if (block == WOOL || block == LOG || block == LEAVES || block == STEP || block == DOUBLESTEP || block == WOOD || block == WOODEN_STEP || block == WOODEN_DOUBLE_STEP 
 		|| block == 95 || block == 160 || block == 159 || block == 171 || block == 38 || block == 175 || block == SAND || block == 153 || block == 166 || block == 167
-		|| block == WATER || block == STAT_WATER
+		|| (g_NoWater && (block == WATER || block == STAT_WATER))
 		|| block == 141 || block == 142 || block == 158 || block == 149 || block == 157
 		|| block == 131 || block == 132 || block == 150 || block == 147 || block == 148 || block == 68 || block == 69 || block == 70
 		|| block == 72 || block == 77 || block == 143 || block == 36) {  //three last lines contains colors for carpets
@@ -1044,7 +1044,7 @@ static inline void assignBlock(const uint8_t &block, uint8_t* &targetBlock, int 
 		}
 		if (block == 131 || block == 132 || block == 150 || block == 147 || block == 148 || block == 68 || block == 69 || block == 70
 			|| block == 72 || block == 77 || block == 143 || block == 36 || block == 166
-			|| (g_NoWater && (block == WATER || block == STAT_WATER))) {		//not visible blocks replaced to air, therefore we have few ID's more
+			|| block == WATER || block == STAT_WATER) {		//not visible blocks replaced to air, therefore we have few ID's more
 				*targetBlock++ = 0;
 		} else if (block == 141 || block == 142) {		//carrots and potatoes -> wheat
 				*targetBlock++ = 59;


### PR DESCRIPTION
...e535b7f2d5eef)

when rendering WITH water (-nowater not set) the assignBlock water case did not hit
and ended in the default else tree, which was only supposed to happen for doublesteps.
Flowing water has a "col" value, depending on its height, so we did hit the
sandstone & wood & cobblestone doublestep case, which is why only height(col 1&2&3)  flowing water
was replaced and the "low" flowing water not.

NOTE: also tested -nowater, still works
Images show the bug (without patch)

![mcmap-bug](https://cloud.githubusercontent.com/assets/775794/3634091/975c9a12-0f15-11e4-9e3a-8a1e88bf3368.png)
![mcmap-bug_orig](https://cloud.githubusercontent.com/assets/775794/3634092/975d8030-0f15-11e4-88b8-eb163302bfa9.png)

